### PR TITLE
Fix configuration updates to preserve user-specified configuration

### DIFF
--- a/neon_phal_plugin_reset/__init__.py
+++ b/neon_phal_plugin_reset/__init__.py
@@ -112,8 +112,8 @@ class DeviceReset(PHALPlugin):
                 LOG.debug("Updating skill config from default")
                 Popen(["/usr/bin/cp", "-r",
                        "/tmp/neon/neon-image-recipe/05_neon_core"
-                       "/overlay/home/neon/.config/neon",
-                       "/home/neon/.config/"])
+                       "/overlay/home/neon/.config/neon/skills",
+                       "/home/neon/.config/neon/"])
                 Popen("chown -R neon:neon /home/neon", shell=True)
             if message.data.get('core_config'):
                 LOG.debug("Updating system config from default")


### PR DESCRIPTION
# Description
Prevent overwriting `~/.config/neon/neon.yaml` when updating default skill configuration

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->