### PR TITLE
Add support for a configured update URL and relative path

### DIFF
--- a/neon_phal_plugin_reset/__init__.py
+++ b/neon_phal_plugin_reset/__init__.py
@@ -114,7 +114,8 @@ class DeviceReset(PHALPlugin):
                          "/home/neon/.config/neon/apps", dirs_exist_ok=True)
             if do_core:
                 LOG.info("updating default core config")
-                copyfile(join(base_config_path, "neon.yaml"), "/etc/neon/neon.yaml")
+                copyfile(join(base_config_path, "neon.yaml"),
+                         "/etc/neon/neon.yaml")
         except Exception as e:
             LOG.exception(e)
         if isdir(default_config_path):

--- a/neon_phal_plugin_reset/__init__.py
+++ b/neon_phal_plugin_reset/__init__.py
@@ -107,11 +107,11 @@ class DeviceReset(PHALPlugin):
             if do_skills:
                 LOG.info("updating default skill config")
                 copytree(join(base_config_path, "skills"),
-                         "/home/neon/.config/neon/")
+                         "/home/neon/.config/neon/skills", dirs_exist_ok=True)
             if do_apps:
                 LOG.info("updating default app config")
                 copytree(join(base_config_path, "apps"),
-                         "/home/neon/.config/neon/")
+                         "/home/neon/.config/neon/apps", dirs_exist_ok=True)
             if do_core:
                 LOG.info("updating default core config")
                 copyfile(join(base_config_path, "neon.yaml"), "/etc/neon/neon.yaml")


### PR DESCRIPTION
# Description
Removes hard-coded `neon-image-recipe` source for configuration updates and makes it configurable to support new structure while maintaining backwards-compat

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->